### PR TITLE
Fix nested any/all evaluation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub struct ParseError<'a> {
 #[derive(Debug, PartialEq)]
 pub enum Reason {
     /// not() takes exactly 1 predicate, unlike all() and any()
-    InvalidNot(u8),
+    InvalidNot(usize),
     /// The characters are not valid in an SDPX license expression
     InvalidCharacters,
     /// An opening parens was unmatched with a closing parens

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -13,11 +13,15 @@ pub enum Func {
     /// `all()` with a comma separated list of configuration predicates. It
     /// is false if at least one predicate is false. If there are no predicates,
     /// it is true.
-    All,
+    ///
+    /// The associated `usize` is the number of predicates inside the `all()`.
+    All(usize),
     /// `any()` with a comma separated list of configuration predicates. It
     /// is true if at least one predicate is true. If there are no predicates,
     /// it is false.
-    Any,
+    ///
+    /// The associated `usize` is the number of predicates inside the `any()`.
+    Any(usize),
 }
 
 use crate::targets as targ;
@@ -192,26 +196,28 @@ impl Expression {
                     let pred = pred.to_pred(&self.original);
                     result_stack.push(eval_predicate(&pred));
                 }
-                ExprNode::Fn(Func::All) => {
+                ExprNode::Fn(Func::All(count)) => {
                     // all() with a comma separated list of configuration predicates.
                     // It is false if at least one predicate is false.
                     // If there are no predicates, it is true.
                     let mut result = true;
 
-                    while let Some(rs) = result_stack.pop() {
-                        result = result && rs;
+                    for _ in 0..*count {
+                        let r = result_stack.pop().unwrap();
+                        result = result && r;
                     }
 
                     result_stack.push(result);
                 }
-                ExprNode::Fn(Func::Any) => {
+                ExprNode::Fn(Func::Any(count)) => {
                     // any() with a comma separated list of configuration predicates.
                     // It is true if at least one predicate is true.
                     // If there are no predicates, it is false.
                     let mut result = false;
 
-                    while let Some(rs) = result_stack.pop() {
-                        result = result || rs;
+                    for _ in 0..*count {
+                        let r = result_stack.pop().unwrap();
+                        result = result || r;
                     }
 
                     result_stack.push(result);

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -127,6 +127,17 @@ fn complex() {
     assert!(complex.eval(|pred| tg_match!(pred, windows_msvc)));
     assert!(complex.eval(|pred| tg_match!(pred, mac)));
     assert!(!complex.eval(|pred| tg_match!(pred, android)));
+
+    let complex = Expression::parse(r#"all(any(unix, target_arch="x86"), not(any(target_os="android", target_os="emscripten")))"#).unwrap();
+
+    // Should match linuxes and mac
+    assert!(complex.eval(|pred| tg_match!(pred, linux_gnu)));
+    assert!(complex.eval(|pred| tg_match!(pred, linux_musl)));
+    assert!(complex.eval(|pred| tg_match!(pred, mac)));
+
+    // Should *not* match x86_64 windows or android
+    assert!(!complex.eval(|pred| tg_match!(pred, windows_msvc)));
+    assert!(!complex.eval(|pred| tg_match!(pred, android)));
 }
 
 #[test]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The current evaluator pops everything on the stack in order to evaluate `any` or `all` queries. That breaks in nested situations like:

```
all(any(unix, target_arch="x86"), not(any(target_os="android", target_os="emscripten")))
```

Fix this by tracking the number of predicates in the `Any` and `All` variants.

This unfortunately breaks semver because the definition of `Func` changes.
`Func` doesn't seem to be exported anywhere so maybe in the upcoming release
it could be made private?