### PR TITLE
Implement evaluation when the result is unknown

### DIFF
--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -166,4 +166,28 @@ fn features() {
             _ => false,
         }
     }));
+
+    assert_eq!(
+        feature_and_target_feature.eval(|pred| {
+            match pred {
+                Predicate::Feature(_) => Some(false),
+                Predicate::TargetFeature(_) => None,
+                _ => panic!("unexpected predicate"),
+            }
+        }),
+        Some(false),
+        "all() with Some(false) and None evaluates to Some(false)"
+    );
+
+    assert_eq!(
+        feature_and_target_feature.eval(|pred| {
+            match pred {
+                Predicate::Feature(_) => Some(true),
+                Predicate::TargetFeature(_) => None,
+                _ => panic!("unexpected predicate"),
+            }
+        }),
+        None,
+        "all() with Some(true) and None evaluates to None"
+    );
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I've run into some situations where the result of evaluating a predicate is
unknown, most notably with target families. Allow evaluating such cases
using a simple three-valued logic.

Do this by making the logic a trait -- its implementation for `bool` is the
standard boolean logic, and its implementation for `Option<bool>` is the
Kleene K3 logic. This logic is also used in SQL.

### Related Issues

Closes #5.
