### PR TITLE
implement PartialEq on Expression

### DIFF
--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -521,6 +521,28 @@ impl Expression {
     }
 }
 
+/// [`PartialEq`] will do a **syntactical** comparaison, so will just check if both
+/// expressions have been parsed from the same string, **not** if they are semantically
+/// equivalents.
+///
+/// ```
+/// use cfg_expr::Expression;
+///
+/// assert_eq!(
+///     Expression::parse("any()").unwrap(),
+///     Expression::parse("any()").unwrap()
+/// );
+/// assert_ne!(
+///     Expression::parse("any()").unwrap(),
+///     Expression::parse("unix").unwrap()
+/// );
+/// ```
+impl PartialEq for Expression {
+    fn eq(&self, other: &Self) -> bool {
+        self.original.eq(&other.original)
+    }
+}
+
 /// A propositional logic used to evaluate `Expression` instances.
 ///
 /// An `Expression` consists of some predicates and the `any`, `all` and `not` operators. An


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

implement PartialEq on Expression

This is useful when storing an expression in a struct which needs to
implement PartialEq.

### Related Issues

Fix #22