### PR TITLE
add Expression::original()

### DIFF
--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -519,6 +519,21 @@ impl Expression {
 
         result_stack.pop().unwrap()
     }
+
+    /// The original string which has been parsed to produce this ['Expression`].
+    ///
+    /// ```
+    /// use cfg_expr::Expression;
+    ///
+    /// assert_eq!(
+    ///     Expression::parse("any()").unwrap().original(),
+    ///     "any()"
+    /// );
+    /// ```
+    #[inline]
+    pub fn original(&self) -> &str {
+        &self.original
+    }
 }
 
 /// [`PartialEq`] will do a **syntactical** comparaison, so will just check if both


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

add Expression::original()

My parser is storing an Expression and may have to retrieve the original string later when producing errors.