### PR TITLE
Build with Rust 1.52

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,10 +52,10 @@ impl fmt::Display for ParseError {
         // Mismatched parens/quotes have a slightly different output
         // than the other errors
         match &self.reason {
-            r @ (Reason::UnclosedParens | Reason::UnclosedQuotes) => {
+            r @ Reason::UnclosedParens | r @ Reason::UnclosedQuotes => {
                 f.write_fmt(format_args!("- {}", r))
             }
-            r @ (Reason::UnopenedParens | Reason::UnopenedQuotes) => {
+            r @ Reason::UnopenedParens | r @ Reason::UnopenedQuotes => {
                 f.write_fmt(format_args!("^ {}", r))
             }
             other => {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -123,15 +123,13 @@ impl TargetMatcher for target_lexicon::Triple {
                     OperatingSystem::Redox => env.0 == "relibc",
                     OperatingSystem::VxWorks => env.0 == "gnu",
                     OperatingSystem::Freebsd => match self.architecture {
-                        Architecture::Arm(ArmArchitecture::Armv6 | ArmArchitecture::Armv7) => {
-                            env.0 == "gnueabihf"
-                        }
+                        Architecture::Arm(ArmArchitecture::Armv6)
+                        | Architecture::Arm(ArmArchitecture::Armv7) => env.0 == "gnueabihf",
                         _ => env.0.is_empty(),
                     },
                     OperatingSystem::Netbsd => match self.architecture {
-                        Architecture::Arm(ArmArchitecture::Armv6 | ArmArchitecture::Armv7) => {
-                            env.0 == "eabihf"
-                        }
+                        Architecture::Arm(ArmArchitecture::Armv6)
+                        | Architecture::Arm(ArmArchitecture::Armv7) => env.0 == "eabihf",
                         _ => env.0.is_empty(),
                     },
                     OperatingSystem::None_

--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -208,7 +208,7 @@ impl Expression {
             ($span:expr) => {{
                 let expected: &[&str] = match last_token {
                     None => &["<key>", "all", "any", "not"],
-                    Some(Token::All | Token::Any | Token::Not) => &["("],
+                    Some(Token::All) | Some(Token::Any) | Some(Token::Not) => &["("],
                     Some(Token::CloseParen) => &[")", ","],
                     Some(Token::Comma) => &[")", "<key>"],
                     Some(Token::Equals) => &["\""],
@@ -235,7 +235,7 @@ impl Expression {
             let lt = lt?;
             match &lt.token {
                 Token::Key(k) => match last_token {
-                    None | Some(Token::OpenParen | Token::Comma) => {
+                    None | Some(Token::OpenParen) | Some(Token::Comma) => {
                         pred_key = Some((k, lt.span.clone()));
                     }
                     _ => token_err!(lt.span),
@@ -256,7 +256,7 @@ impl Expression {
                     _ => token_err!(lt.span),
                 },
                 Token::All | Token::Any | Token::Not => match last_token {
-                    None | Some(Token::OpenParen | Token::Comma) => {
+                    None | Some(Token::OpenParen) | Some(Token::Comma) => {
                         let new_fn = match lt.token {
                             // the 0 is a dummy value -- it will be substituted for the real
                             // number of predicates in the `CloseParen` branch below.
@@ -281,7 +281,7 @@ impl Expression {
                     _ => token_err!(lt.span),
                 },
                 Token::OpenParen => match last_token {
-                    Some(Token::All | Token::Any | Token::Not) => {
+                    Some(Token::All) | Some(Token::Any) | Some(Token::Not) => {
                         if let Some(ref mut fs) = func_stack.last_mut() {
                             fs.parens_index = lt.span.start;
                         }
@@ -289,7 +289,8 @@ impl Expression {
                     _ => token_err!(lt.span),
                 },
                 Token::CloseParen => match last_token {
-                    None | Some(Token::All | Token::Any | Token::Not | Token::Equals) => {
+                    None | Some(Token::All) | Some(Token::Any) | Some(Token::Not)
+                    | Some(Token::Equals) => {
                         token_err!(lt.span)
                     }
                     _ => {
@@ -346,9 +347,11 @@ impl Expression {
                 },
                 Token::Comma => match last_token {
                     None
-                    | Some(
-                        Token::OpenParen | Token::All | Token::Any | Token::Not | Token::Equals,
-                    ) => token_err!(lt.span),
+                    | Some(Token::OpenParen)
+                    | Some(Token::All)
+                    | Some(Token::Any)
+                    | Some(Token::Not)
+                    | Some(Token::Equals) => token_err!(lt.span),
                     _ => {
                         let key = pred_key.take();
                         let val = pred_val.take();


### PR DESCRIPTION
This crate is a dependency of `system-deps` which is a pretty
foundational library.  In my case, we use the `glib` and gtk-rs bindings
which transitively depend on this.

Not everyone can move at upstream Rust speed.  While there are improvements,
there are sometimes regressions too (thankfully, not many, but still).

In this case, I hope you'd agree that while the new "or pattern" feature
is *nice* it's far from a must have.  (Unlike e.g. const generics or so)
