### PR TITLE
switch TargetInfo to using Cow<'static, str>

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -1,4 +1,5 @@
 use crate::error::Reason;
+use std::borrow::Cow;
 
 mod builtins;
 
@@ -6,24 +7,73 @@ mod builtins;
 /// targets known to rustc, as of 1.49.0
 pub use builtins::ALL_BUILTINS;
 
+/// The unique identifier for a target.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Triple(pub Cow<'static, str>);
+
 /// The "architecture" field
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Arch<'a>(pub &'a str);
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Arch(pub Cow<'static, str>);
 
 /// The "vendor" field, which in practice is little more than an arbitrary modifier.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Vendor<'a>(pub &'a str);
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Vendor(pub Cow<'static, str>);
 
 /// The "operating system" field, which sometimes implies an environment, and
 /// sometimes isn't an actual operating system.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Os<'a>(pub &'a str);
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Os(pub Cow<'static, str>);
 
 /// The "environment" field, which specifies an ABI environment on top of the
 /// operating system. In many configurations, this field is omitted, and the
 /// environment is implied by the operating system.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Env<'a>(pub &'a str);
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Env(pub Cow<'static, str>);
+
+macro_rules! field_impls {
+    ($kind:ident) => {
+        impl $kind {
+            /// Constructs a new instance of this field.
+            ///
+            /// This method accepts both owned `String`s and `&'static str`s.
+            #[inline]
+            pub fn new(val: impl Into<Cow<'static, str>>) -> Self {
+                Self(val.into())
+            }
+
+            /// Constructs a new instance of this field from a `&'static str`.
+            #[inline]
+            pub const fn new_const(val: &'static str) -> Self {
+                Self(Cow::Borrowed(val))
+            }
+
+            /// Returns the string for the field.
+            #[inline]
+            pub fn as_str(&self) -> &str {
+                &*self.0
+            }
+        }
+
+        impl AsRef<str> for $kind {
+            #[inline]
+            fn as_ref(&self) -> &str {
+                &*self.0
+            }
+        }
+
+        impl std::fmt::Display for $kind {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+    };
+}
+
+field_impls!(Triple);
+field_impls!(Arch);
+field_impls!(Vendor);
+field_impls!(Os);
+field_impls!(Env);
 
 macro_rules! target_enum {
     (
@@ -98,25 +148,25 @@ target_enum! {
 
 /// Contains information regarding a particular target known to rustc
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct TargetInfo<'a> {
+pub struct TargetInfo {
     /// The target's unique identifier
-    pub triple: &'a str,
+    pub triple: Triple,
     /// The target's operating system, if any. Used by the
     /// [target_os](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os)
     /// predicate.
-    pub os: Option<Os<'a>>,
+    pub os: Option<Os>,
     /// The target's CPU architecture. Used by the
     /// [target_arch](https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch)
     /// predicate.
-    pub arch: Arch<'a>,
+    pub arch: Arch,
     /// The target's ABI/libc used, if any. Used by the
     /// [target_env](https://doc.rust-lang.org/reference/conditional-compilation.html#target_env)
     /// predicate.
-    pub env: Option<Env<'a>>,
+    pub env: Option<Env>,
     /// The target's vendor, if any. Used by the
     /// [target_vendor](https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor)
     /// predicate.
-    pub vendor: Option<Vendor<'a>>,
+    pub vendor: Option<Vendor>,
     /// The target's family, if any. Used by the
     /// [target_family](https://doc.rust-lang.org/reference/conditional-compilation.html#target_family)
     /// predicate.
@@ -136,9 +186,9 @@ pub struct TargetInfo<'a> {
 /// ```
 /// assert!(cfg_expr::targets::get_builtin_target_by_triple("x86_64-unknown-linux-musl").is_some());
 /// ```
-pub fn get_builtin_target_by_triple(triple: &str) -> Option<&'static TargetInfo<'static>> {
+pub fn get_builtin_target_by_triple(triple: &str) -> Option<&'static TargetInfo> {
     ALL_BUILTINS
-        .binary_search_by(|ti| ti.triple.cmp(triple))
+        .binary_search_by(|ti| ti.triple.as_ref().cmp(triple))
         .map(|i| &ALL_BUILTINS[i])
         .ok()
 }

--- a/src/targets/builtins.rs
+++ b/src/targets/builtins.rs
@@ -12,9 +12,9 @@ use super::*;
 
 pub(crate) const RUSTC_VERSION: &str = "1.53.0";
 
-pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
+pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
-        triple: "aarch64-apple-darwin",
+        triple: Triple::new_const("aarch64-apple-darwin"),
         os: Some(Os::macos),
         arch: Arch::aarch64,
         env: None,
@@ -24,7 +24,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-apple-ios",
+        triple: Triple::new_const("aarch64-apple-ios"),
         os: Some(Os::ios),
         arch: Arch::aarch64,
         env: None,
@@ -34,7 +34,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-apple-ios-macabi",
+        triple: Triple::new_const("aarch64-apple-ios-macabi"),
         os: Some(Os::ios),
         arch: Arch::aarch64,
         env: None,
@@ -44,7 +44,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-apple-ios-sim",
+        triple: Triple::new_const("aarch64-apple-ios-sim"),
         os: Some(Os::ios),
         arch: Arch::aarch64,
         env: None,
@@ -54,7 +54,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-apple-tvos",
+        triple: Triple::new_const("aarch64-apple-tvos"),
         os: Some(Os::tvos),
         arch: Arch::aarch64,
         env: None,
@@ -64,7 +64,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-fuchsia",
+        triple: Triple::new_const("aarch64-fuchsia"),
         os: Some(Os::fuchsia),
         arch: Arch::aarch64,
         env: None,
@@ -74,7 +74,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-linux-android",
+        triple: Triple::new_const("aarch64-linux-android"),
         os: Some(Os::android),
         arch: Arch::aarch64,
         env: Some(Env::gnu),
@@ -84,7 +84,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-pc-windows-msvc",
+        triple: Triple::new_const("aarch64-pc-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::aarch64,
         env: Some(Env::msvc),
@@ -94,7 +94,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-freebsd",
+        triple: Triple::new_const("aarch64-unknown-freebsd"),
         os: Some(Os::freebsd),
         arch: Arch::aarch64,
         env: None,
@@ -104,7 +104,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-hermit",
+        triple: Triple::new_const("aarch64-unknown-hermit"),
         os: Some(Os::hermit),
         arch: Arch::aarch64,
         env: None,
@@ -114,7 +114,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-linux-gnu",
+        triple: Triple::new_const("aarch64-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::aarch64,
         env: Some(Env::gnu),
@@ -124,7 +124,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-linux-gnu_ilp32",
+        triple: Triple::new_const("aarch64-unknown-linux-gnu_ilp32"),
         os: Some(Os::linux),
         arch: Arch::aarch64,
         env: Some(Env::gnu),
@@ -134,7 +134,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-linux-musl",
+        triple: Triple::new_const("aarch64-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::aarch64,
         env: Some(Env::musl),
@@ -144,7 +144,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-netbsd",
+        triple: Triple::new_const("aarch64-unknown-netbsd"),
         os: Some(Os::netbsd),
         arch: Arch::aarch64,
         env: None,
@@ -154,7 +154,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-none",
+        triple: Triple::new_const("aarch64-unknown-none"),
         os: None,
         arch: Arch::aarch64,
         env: None,
@@ -164,7 +164,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-none-softfloat",
+        triple: Triple::new_const("aarch64-unknown-none-softfloat"),
         os: None,
         arch: Arch::aarch64,
         env: None,
@@ -174,7 +174,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-openbsd",
+        triple: Triple::new_const("aarch64-unknown-openbsd"),
         os: Some(Os::openbsd),
         arch: Arch::aarch64,
         env: None,
@@ -184,7 +184,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-unknown-redox",
+        triple: Triple::new_const("aarch64-unknown-redox"),
         os: Some(Os::redox),
         arch: Arch::aarch64,
         env: Some(Env::relibc),
@@ -194,7 +194,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-uwp-windows-msvc",
+        triple: Triple::new_const("aarch64-uwp-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::aarch64,
         env: Some(Env::msvc),
@@ -204,7 +204,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64-wrs-vxworks",
+        triple: Triple::new_const("aarch64-wrs-vxworks"),
         os: Some(Os::vxworks),
         arch: Arch::aarch64,
         env: Some(Env::gnu),
@@ -214,7 +214,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "aarch64_be-unknown-linux-gnu",
+        triple: Triple::new_const("aarch64_be-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::aarch64,
         env: Some(Env::gnu),
@@ -224,7 +224,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "aarch64_be-unknown-linux-gnu_ilp32",
+        triple: Triple::new_const("aarch64_be-unknown-linux-gnu_ilp32"),
         os: Some(Os::linux),
         arch: Arch::aarch64,
         env: Some(Env::gnu),
@@ -234,7 +234,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "arm-linux-androideabi",
+        triple: Triple::new_const("arm-linux-androideabi"),
         os: Some(Os::android),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -244,7 +244,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "arm-unknown-linux-gnueabi",
+        triple: Triple::new_const("arm-unknown-linux-gnueabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -254,7 +254,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "arm-unknown-linux-gnueabihf",
+        triple: Triple::new_const("arm-unknown-linux-gnueabihf"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -264,7 +264,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "arm-unknown-linux-musleabi",
+        triple: Triple::new_const("arm-unknown-linux-musleabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::musl),
@@ -274,7 +274,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "arm-unknown-linux-musleabihf",
+        triple: Triple::new_const("arm-unknown-linux-musleabihf"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::musl),
@@ -284,7 +284,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armebv7r-none-eabi",
+        triple: Triple::new_const("armebv7r-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -294,7 +294,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "armebv7r-none-eabihf",
+        triple: Triple::new_const("armebv7r-none-eabihf"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -304,7 +304,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "armv4t-unknown-linux-gnueabi",
+        triple: Triple::new_const("armv4t-unknown-linux-gnueabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -314,7 +314,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv5te-unknown-linux-gnueabi",
+        triple: Triple::new_const("armv5te-unknown-linux-gnueabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -324,7 +324,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv5te-unknown-linux-musleabi",
+        triple: Triple::new_const("armv5te-unknown-linux-musleabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::musl),
@@ -334,7 +334,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv5te-unknown-linux-uclibceabi",
+        triple: Triple::new_const("armv5te-unknown-linux-uclibceabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::uclibc),
@@ -344,7 +344,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv6-unknown-freebsd",
+        triple: Triple::new_const("armv6-unknown-freebsd"),
         os: Some(Os::freebsd),
         arch: Arch::arm,
         env: Some(Env::gnueabihf),
@@ -354,7 +354,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv6-unknown-netbsd-eabihf",
+        triple: Triple::new_const("armv6-unknown-netbsd-eabihf"),
         os: Some(Os::netbsd),
         arch: Arch::arm,
         env: Some(Env::eabihf),
@@ -364,7 +364,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-apple-ios",
+        triple: Triple::new_const("armv7-apple-ios"),
         os: Some(Os::ios),
         arch: Arch::arm,
         env: None,
@@ -374,7 +374,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-linux-androideabi",
+        triple: Triple::new_const("armv7-linux-androideabi"),
         os: Some(Os::android),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -384,7 +384,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-unknown-freebsd",
+        triple: Triple::new_const("armv7-unknown-freebsd"),
         os: Some(Os::freebsd),
         arch: Arch::arm,
         env: Some(Env::gnueabihf),
@@ -394,7 +394,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-unknown-linux-gnueabi",
+        triple: Triple::new_const("armv7-unknown-linux-gnueabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -404,7 +404,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-unknown-linux-gnueabihf",
+        triple: Triple::new_const("armv7-unknown-linux-gnueabihf"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -414,7 +414,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-unknown-linux-musleabi",
+        triple: Triple::new_const("armv7-unknown-linux-musleabi"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::musl),
@@ -424,7 +424,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-unknown-linux-musleabihf",
+        triple: Triple::new_const("armv7-unknown-linux-musleabihf"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::musl),
@@ -434,7 +434,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-unknown-netbsd-eabihf",
+        triple: Triple::new_const("armv7-unknown-netbsd-eabihf"),
         os: Some(Os::netbsd),
         arch: Arch::arm,
         env: Some(Env::eabihf),
@@ -444,7 +444,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7-wrs-vxworks-eabihf",
+        triple: Triple::new_const("armv7-wrs-vxworks-eabihf"),
         os: Some(Os::vxworks),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -454,7 +454,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7a-none-eabi",
+        triple: Triple::new_const("armv7a-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -464,7 +464,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7a-none-eabihf",
+        triple: Triple::new_const("armv7a-none-eabihf"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -474,7 +474,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7r-none-eabi",
+        triple: Triple::new_const("armv7r-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -484,7 +484,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7r-none-eabihf",
+        triple: Triple::new_const("armv7r-none-eabihf"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -494,7 +494,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "armv7s-apple-ios",
+        triple: Triple::new_const("armv7s-apple-ios"),
         os: Some(Os::ios),
         arch: Arch::arm,
         env: None,
@@ -504,7 +504,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "asmjs-unknown-emscripten",
+        triple: Triple::new_const("asmjs-unknown-emscripten"),
         os: Some(Os::emscripten),
         arch: Arch::wasm32,
         env: None,
@@ -514,7 +514,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "avr-unknown-gnu-atmega328",
+        triple: Triple::new_const("avr-unknown-gnu-atmega328"),
         os: None,
         arch: Arch::avr,
         env: None,
@@ -524,7 +524,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "hexagon-unknown-linux-musl",
+        triple: Triple::new_const("hexagon-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::hexagon,
         env: Some(Env::musl),
@@ -534,7 +534,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i386-apple-ios",
+        triple: Triple::new_const("i386-apple-ios"),
         os: Some(Os::ios),
         arch: Arch::x86,
         env: None,
@@ -544,7 +544,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i586-pc-windows-msvc",
+        triple: Triple::new_const("i586-pc-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::x86,
         env: Some(Env::msvc),
@@ -554,7 +554,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i586-unknown-linux-gnu",
+        triple: Triple::new_const("i586-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::x86,
         env: Some(Env::gnu),
@@ -564,7 +564,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i586-unknown-linux-musl",
+        triple: Triple::new_const("i586-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::x86,
         env: Some(Env::musl),
@@ -574,7 +574,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-apple-darwin",
+        triple: Triple::new_const("i686-apple-darwin"),
         os: Some(Os::macos),
         arch: Arch::x86,
         env: None,
@@ -584,7 +584,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-linux-android",
+        triple: Triple::new_const("i686-linux-android"),
         os: Some(Os::android),
         arch: Arch::x86,
         env: Some(Env::gnu),
@@ -594,7 +594,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-pc-windows-gnu",
+        triple: Triple::new_const("i686-pc-windows-gnu"),
         os: Some(Os::windows),
         arch: Arch::x86,
         env: Some(Env::gnu),
@@ -604,7 +604,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-pc-windows-msvc",
+        triple: Triple::new_const("i686-pc-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::x86,
         env: Some(Env::msvc),
@@ -614,7 +614,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-unknown-freebsd",
+        triple: Triple::new_const("i686-unknown-freebsd"),
         os: Some(Os::freebsd),
         arch: Arch::x86,
         env: None,
@@ -624,7 +624,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-unknown-haiku",
+        triple: Triple::new_const("i686-unknown-haiku"),
         os: Some(Os::haiku),
         arch: Arch::x86,
         env: None,
@@ -634,7 +634,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-unknown-linux-gnu",
+        triple: Triple::new_const("i686-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::x86,
         env: Some(Env::gnu),
@@ -644,7 +644,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-unknown-linux-musl",
+        triple: Triple::new_const("i686-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::x86,
         env: Some(Env::musl),
@@ -654,7 +654,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-unknown-netbsd",
+        triple: Triple::new_const("i686-unknown-netbsd"),
         os: Some(Os::netbsd),
         arch: Arch::x86,
         env: None,
@@ -664,7 +664,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-unknown-openbsd",
+        triple: Triple::new_const("i686-unknown-openbsd"),
         os: Some(Os::openbsd),
         arch: Arch::x86,
         env: None,
@@ -674,7 +674,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-unknown-uefi",
+        triple: Triple::new_const("i686-unknown-uefi"),
         os: Some(Os::uefi),
         arch: Arch::x86,
         env: None,
@@ -684,7 +684,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-uwp-windows-gnu",
+        triple: Triple::new_const("i686-uwp-windows-gnu"),
         os: Some(Os::windows),
         arch: Arch::x86,
         env: Some(Env::gnu),
@@ -694,7 +694,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-uwp-windows-msvc",
+        triple: Triple::new_const("i686-uwp-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::x86,
         env: Some(Env::msvc),
@@ -704,7 +704,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "i686-wrs-vxworks",
+        triple: Triple::new_const("i686-wrs-vxworks"),
         os: Some(Os::vxworks),
         arch: Arch::x86,
         env: Some(Env::gnu),
@@ -714,7 +714,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mips-unknown-linux-gnu",
+        triple: Triple::new_const("mips-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::gnu),
@@ -724,7 +724,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "mips-unknown-linux-musl",
+        triple: Triple::new_const("mips-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::musl),
@@ -734,7 +734,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "mips-unknown-linux-uclibc",
+        triple: Triple::new_const("mips-unknown-linux-uclibc"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::uclibc),
@@ -744,7 +744,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "mips64-unknown-linux-gnuabi64",
+        triple: Triple::new_const("mips64-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
         arch: Arch::mips64,
         env: Some(Env::gnu),
@@ -754,7 +754,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "mips64-unknown-linux-muslabi64",
+        triple: Triple::new_const("mips64-unknown-linux-muslabi64"),
         os: Some(Os::linux),
         arch: Arch::mips64,
         env: Some(Env::musl),
@@ -764,7 +764,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "mips64el-unknown-linux-gnuabi64",
+        triple: Triple::new_const("mips64el-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
         arch: Arch::mips64,
         env: Some(Env::gnu),
@@ -774,7 +774,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mips64el-unknown-linux-muslabi64",
+        triple: Triple::new_const("mips64el-unknown-linux-muslabi64"),
         os: Some(Os::linux),
         arch: Arch::mips64,
         env: Some(Env::musl),
@@ -784,7 +784,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mipsel-sony-psp",
+        triple: Triple::new_const("mipsel-sony-psp"),
         os: Some(Os::psp),
         arch: Arch::mips,
         env: None,
@@ -794,7 +794,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mipsel-unknown-linux-gnu",
+        triple: Triple::new_const("mipsel-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::gnu),
@@ -804,7 +804,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mipsel-unknown-linux-musl",
+        triple: Triple::new_const("mipsel-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::musl),
@@ -814,7 +814,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mipsel-unknown-linux-uclibc",
+        triple: Triple::new_const("mipsel-unknown-linux-uclibc"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::uclibc),
@@ -824,7 +824,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mipsel-unknown-none",
+        triple: Triple::new_const("mipsel-unknown-none"),
         os: None,
         arch: Arch::mips,
         env: None,
@@ -834,7 +834,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mipsisa32r6-unknown-linux-gnu",
+        triple: Triple::new_const("mipsisa32r6-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::gnu),
@@ -844,7 +844,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "mipsisa32r6el-unknown-linux-gnu",
+        triple: Triple::new_const("mipsisa32r6el-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::mips,
         env: Some(Env::gnu),
@@ -854,7 +854,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "mipsisa64r6-unknown-linux-gnuabi64",
+        triple: Triple::new_const("mipsisa64r6-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
         arch: Arch::mips64,
         env: Some(Env::gnu),
@@ -864,7 +864,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "mipsisa64r6el-unknown-linux-gnuabi64",
+        triple: Triple::new_const("mipsisa64r6el-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
         arch: Arch::mips64,
         env: Some(Env::gnu),
@@ -874,7 +874,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "msp430-none-elf",
+        triple: Triple::new_const("msp430-none-elf"),
         os: None,
         arch: Arch::msp430,
         env: None,
@@ -884,7 +884,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "nvptx64-nvidia-cuda",
+        triple: Triple::new_const("nvptx64-nvidia-cuda"),
         os: Some(Os::cuda),
         arch: Arch::nvptx64,
         env: None,
@@ -894,7 +894,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "powerpc-unknown-linux-gnu",
+        triple: Triple::new_const("powerpc-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::powerpc,
         env: Some(Env::gnu),
@@ -904,7 +904,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc-unknown-linux-gnuspe",
+        triple: Triple::new_const("powerpc-unknown-linux-gnuspe"),
         os: Some(Os::linux),
         arch: Arch::powerpc,
         env: Some(Env::gnu),
@@ -914,7 +914,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc-unknown-linux-musl",
+        triple: Triple::new_const("powerpc-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::powerpc,
         env: Some(Env::musl),
@@ -924,7 +924,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc-unknown-netbsd",
+        triple: Triple::new_const("powerpc-unknown-netbsd"),
         os: Some(Os::netbsd),
         arch: Arch::powerpc,
         env: None,
@@ -934,7 +934,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc-unknown-openbsd",
+        triple: Triple::new_const("powerpc-unknown-openbsd"),
         os: Some(Os::openbsd),
         arch: Arch::powerpc,
         env: None,
@@ -944,7 +944,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc-wrs-vxworks",
+        triple: Triple::new_const("powerpc-wrs-vxworks"),
         os: Some(Os::vxworks),
         arch: Arch::powerpc,
         env: Some(Env::gnu),
@@ -954,7 +954,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc-wrs-vxworks-spe",
+        triple: Triple::new_const("powerpc-wrs-vxworks-spe"),
         os: Some(Os::vxworks),
         arch: Arch::powerpc,
         env: Some(Env::gnu),
@@ -964,7 +964,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc64-unknown-freebsd",
+        triple: Triple::new_const("powerpc64-unknown-freebsd"),
         os: Some(Os::freebsd),
         arch: Arch::powerpc64,
         env: None,
@@ -974,7 +974,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc64-unknown-linux-gnu",
+        triple: Triple::new_const("powerpc64-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::powerpc64,
         env: Some(Env::gnu),
@@ -984,7 +984,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc64-unknown-linux-musl",
+        triple: Triple::new_const("powerpc64-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::powerpc64,
         env: Some(Env::musl),
@@ -994,7 +994,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc64-wrs-vxworks",
+        triple: Triple::new_const("powerpc64-wrs-vxworks"),
         os: Some(Os::vxworks),
         arch: Arch::powerpc64,
         env: Some(Env::gnu),
@@ -1004,7 +1004,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "powerpc64le-unknown-linux-gnu",
+        triple: Triple::new_const("powerpc64le-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::powerpc64,
         env: Some(Env::gnu),
@@ -1014,7 +1014,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "powerpc64le-unknown-linux-musl",
+        triple: Triple::new_const("powerpc64le-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::powerpc64,
         env: Some(Env::musl),
@@ -1024,7 +1024,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv32gc-unknown-linux-gnu",
+        triple: Triple::new_const("riscv32gc-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::riscv32,
         env: Some(Env::gnu),
@@ -1034,7 +1034,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv32gc-unknown-linux-musl",
+        triple: Triple::new_const("riscv32gc-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::riscv32,
         env: Some(Env::musl),
@@ -1044,7 +1044,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv32i-unknown-none-elf",
+        triple: Triple::new_const("riscv32i-unknown-none-elf"),
         os: None,
         arch: Arch::riscv32,
         env: None,
@@ -1054,7 +1054,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv32imac-unknown-none-elf",
+        triple: Triple::new_const("riscv32imac-unknown-none-elf"),
         os: None,
         arch: Arch::riscv32,
         env: None,
@@ -1064,7 +1064,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv32imc-unknown-none-elf",
+        triple: Triple::new_const("riscv32imc-unknown-none-elf"),
         os: None,
         arch: Arch::riscv32,
         env: None,
@@ -1074,7 +1074,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv64gc-unknown-linux-gnu",
+        triple: Triple::new_const("riscv64gc-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::riscv64,
         env: Some(Env::gnu),
@@ -1084,7 +1084,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv64gc-unknown-linux-musl",
+        triple: Triple::new_const("riscv64gc-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::riscv64,
         env: Some(Env::musl),
@@ -1094,7 +1094,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv64gc-unknown-none-elf",
+        triple: Triple::new_const("riscv64gc-unknown-none-elf"),
         os: None,
         arch: Arch::riscv64,
         env: None,
@@ -1104,7 +1104,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "riscv64imac-unknown-none-elf",
+        triple: Triple::new_const("riscv64imac-unknown-none-elf"),
         os: None,
         arch: Arch::riscv64,
         env: None,
@@ -1114,7 +1114,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "s390x-unknown-linux-gnu",
+        triple: Triple::new_const("s390x-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::s390x,
         env: Some(Env::gnu),
@@ -1124,7 +1124,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "s390x-unknown-linux-musl",
+        triple: Triple::new_const("s390x-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::s390x,
         env: Some(Env::musl),
@@ -1134,7 +1134,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "sparc-unknown-linux-gnu",
+        triple: Triple::new_const("sparc-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::sparc,
         env: Some(Env::gnu),
@@ -1144,7 +1144,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "sparc64-unknown-linux-gnu",
+        triple: Triple::new_const("sparc64-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::sparc64,
         env: Some(Env::gnu),
@@ -1154,7 +1154,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "sparc64-unknown-netbsd",
+        triple: Triple::new_const("sparc64-unknown-netbsd"),
         os: Some(Os::netbsd),
         arch: Arch::sparc64,
         env: None,
@@ -1164,7 +1164,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "sparc64-unknown-openbsd",
+        triple: Triple::new_const("sparc64-unknown-openbsd"),
         os: Some(Os::openbsd),
         arch: Arch::sparc64,
         env: None,
@@ -1174,7 +1174,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "sparcv9-sun-solaris",
+        triple: Triple::new_const("sparcv9-sun-solaris"),
         os: Some(Os::solaris),
         arch: Arch::sparc64,
         env: None,
@@ -1184,7 +1184,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::big,
     },
     TargetInfo {
-        triple: "thumbv4t-none-eabi",
+        triple: Triple::new_const("thumbv4t-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1194,7 +1194,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv6m-none-eabi",
+        triple: Triple::new_const("thumbv6m-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1204,7 +1204,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7a-pc-windows-msvc",
+        triple: Triple::new_const("thumbv7a-pc-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::arm,
         env: Some(Env::msvc),
@@ -1214,7 +1214,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7a-uwp-windows-msvc",
+        triple: Triple::new_const("thumbv7a-uwp-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::arm,
         env: Some(Env::msvc),
@@ -1224,7 +1224,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7em-none-eabi",
+        triple: Triple::new_const("thumbv7em-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1234,7 +1234,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7em-none-eabihf",
+        triple: Triple::new_const("thumbv7em-none-eabihf"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1244,7 +1244,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7m-none-eabi",
+        triple: Triple::new_const("thumbv7m-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1254,7 +1254,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7neon-linux-androideabi",
+        triple: Triple::new_const("thumbv7neon-linux-androideabi"),
         os: Some(Os::android),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -1264,7 +1264,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7neon-unknown-linux-gnueabihf",
+        triple: Triple::new_const("thumbv7neon-unknown-linux-gnueabihf"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::gnu),
@@ -1274,7 +1274,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv7neon-unknown-linux-musleabihf",
+        triple: Triple::new_const("thumbv7neon-unknown-linux-musleabihf"),
         os: Some(Os::linux),
         arch: Arch::arm,
         env: Some(Env::musl),
@@ -1284,7 +1284,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv8m.base-none-eabi",
+        triple: Triple::new_const("thumbv8m.base-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1294,7 +1294,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv8m.main-none-eabi",
+        triple: Triple::new_const("thumbv8m.main-none-eabi"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1304,7 +1304,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "thumbv8m.main-none-eabihf",
+        triple: Triple::new_const("thumbv8m.main-none-eabihf"),
         os: None,
         arch: Arch::arm,
         env: None,
@@ -1314,7 +1314,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "wasm32-unknown-emscripten",
+        triple: Triple::new_const("wasm32-unknown-emscripten"),
         os: Some(Os::emscripten),
         arch: Arch::wasm32,
         env: None,
@@ -1324,7 +1324,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "wasm32-unknown-unknown",
+        triple: Triple::new_const("wasm32-unknown-unknown"),
         os: Some(Os::unknown),
         arch: Arch::wasm32,
         env: None,
@@ -1334,7 +1334,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "wasm32-wasi",
+        triple: Triple::new_const("wasm32-wasi"),
         os: Some(Os::wasi),
         arch: Arch::wasm32,
         env: None,
@@ -1344,7 +1344,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "wasm64-unknown-unknown",
+        triple: Triple::new_const("wasm64-unknown-unknown"),
         os: Some(Os::unknown),
         arch: Arch::wasm64,
         env: None,
@@ -1354,7 +1354,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-apple-darwin",
+        triple: Triple::new_const("x86_64-apple-darwin"),
         os: Some(Os::macos),
         arch: Arch::x86_64,
         env: None,
@@ -1364,7 +1364,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-apple-ios",
+        triple: Triple::new_const("x86_64-apple-ios"),
         os: Some(Os::ios),
         arch: Arch::x86_64,
         env: None,
@@ -1374,7 +1374,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-apple-ios-macabi",
+        triple: Triple::new_const("x86_64-apple-ios-macabi"),
         os: Some(Os::ios),
         arch: Arch::x86_64,
         env: None,
@@ -1384,7 +1384,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-apple-tvos",
+        triple: Triple::new_const("x86_64-apple-tvos"),
         os: Some(Os::tvos),
         arch: Arch::x86_64,
         env: None,
@@ -1394,7 +1394,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-fortanix-unknown-sgx",
+        triple: Triple::new_const("x86_64-fortanix-unknown-sgx"),
         os: Some(Os::unknown),
         arch: Arch::x86_64,
         env: Some(Env::sgx),
@@ -1404,7 +1404,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-fuchsia",
+        triple: Triple::new_const("x86_64-fuchsia"),
         os: Some(Os::fuchsia),
         arch: Arch::x86_64,
         env: None,
@@ -1414,7 +1414,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-linux-android",
+        triple: Triple::new_const("x86_64-linux-android"),
         os: Some(Os::android),
         arch: Arch::x86_64,
         env: Some(Env::gnu),
@@ -1424,7 +1424,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-pc-solaris",
+        triple: Triple::new_const("x86_64-pc-solaris"),
         os: Some(Os::solaris),
         arch: Arch::x86_64,
         env: None,
@@ -1434,7 +1434,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-pc-windows-gnu",
+        triple: Triple::new_const("x86_64-pc-windows-gnu"),
         os: Some(Os::windows),
         arch: Arch::x86_64,
         env: Some(Env::gnu),
@@ -1444,7 +1444,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-pc-windows-msvc",
+        triple: Triple::new_const("x86_64-pc-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::x86_64,
         env: Some(Env::msvc),
@@ -1454,7 +1454,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-sun-solaris",
+        triple: Triple::new_const("x86_64-sun-solaris"),
         os: Some(Os::solaris),
         arch: Arch::x86_64,
         env: None,
@@ -1464,7 +1464,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-dragonfly",
+        triple: Triple::new_const("x86_64-unknown-dragonfly"),
         os: Some(Os::dragonfly),
         arch: Arch::x86_64,
         env: None,
@@ -1474,7 +1474,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-freebsd",
+        triple: Triple::new_const("x86_64-unknown-freebsd"),
         os: Some(Os::freebsd),
         arch: Arch::x86_64,
         env: None,
@@ -1484,7 +1484,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-haiku",
+        triple: Triple::new_const("x86_64-unknown-haiku"),
         os: Some(Os::haiku),
         arch: Arch::x86_64,
         env: None,
@@ -1494,7 +1494,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-hermit",
+        triple: Triple::new_const("x86_64-unknown-hermit"),
         os: Some(Os::hermit),
         arch: Arch::x86_64,
         env: None,
@@ -1504,7 +1504,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-illumos",
+        triple: Triple::new_const("x86_64-unknown-illumos"),
         os: Some(Os::illumos),
         arch: Arch::x86_64,
         env: None,
@@ -1514,7 +1514,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-l4re-uclibc",
+        triple: Triple::new_const("x86_64-unknown-l4re-uclibc"),
         os: Some(Os::l4re),
         arch: Arch::x86_64,
         env: Some(Env::uclibc),
@@ -1524,7 +1524,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-linux-gnu",
+        triple: Triple::new_const("x86_64-unknown-linux-gnu"),
         os: Some(Os::linux),
         arch: Arch::x86_64,
         env: Some(Env::gnu),
@@ -1534,7 +1534,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-linux-gnux32",
+        triple: Triple::new_const("x86_64-unknown-linux-gnux32"),
         os: Some(Os::linux),
         arch: Arch::x86_64,
         env: Some(Env::gnu),
@@ -1544,7 +1544,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-linux-musl",
+        triple: Triple::new_const("x86_64-unknown-linux-musl"),
         os: Some(Os::linux),
         arch: Arch::x86_64,
         env: Some(Env::musl),
@@ -1554,7 +1554,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-netbsd",
+        triple: Triple::new_const("x86_64-unknown-netbsd"),
         os: Some(Os::netbsd),
         arch: Arch::x86_64,
         env: None,
@@ -1564,7 +1564,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-none-hermitkernel",
+        triple: Triple::new_const("x86_64-unknown-none-hermitkernel"),
         os: Some(Os::hermit),
         arch: Arch::x86_64,
         env: None,
@@ -1574,7 +1574,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-none-linuxkernel",
+        triple: Triple::new_const("x86_64-unknown-none-linuxkernel"),
         os: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
@@ -1584,7 +1584,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-openbsd",
+        triple: Triple::new_const("x86_64-unknown-openbsd"),
         os: Some(Os::openbsd),
         arch: Arch::x86_64,
         env: None,
@@ -1594,7 +1594,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-redox",
+        triple: Triple::new_const("x86_64-unknown-redox"),
         os: Some(Os::redox),
         arch: Arch::x86_64,
         env: Some(Env::relibc),
@@ -1604,7 +1604,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-unknown-uefi",
+        triple: Triple::new_const("x86_64-unknown-uefi"),
         os: Some(Os::uefi),
         arch: Arch::x86_64,
         env: None,
@@ -1614,7 +1614,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-uwp-windows-gnu",
+        triple: Triple::new_const("x86_64-uwp-windows-gnu"),
         os: Some(Os::windows),
         arch: Arch::x86_64,
         env: Some(Env::gnu),
@@ -1624,7 +1624,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-uwp-windows-msvc",
+        triple: Triple::new_const("x86_64-uwp-windows-msvc"),
         os: Some(Os::windows),
         arch: Arch::x86_64,
         env: Some(Env::msvc),
@@ -1634,7 +1634,7 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
         endian: Endian::little,
     },
     TargetInfo {
-        triple: "x86_64-wrs-vxworks",
+        triple: Triple::new_const("x86_64-wrs-vxworks"),
         os: Some(Os::vxworks),
         arch: Arch::x86_64,
         env: Some(Env::gnu),
@@ -1645,74 +1645,74 @@ pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
     },
 ];
 
-impl<'a> super::Arch<'a> {
-    pub const aarch64: Arch<'static> = Arch("aarch64");
-    pub const arm: Arch<'static> = Arch("arm");
-    pub const avr: Arch<'static> = Arch("avr");
-    pub const hexagon: Arch<'static> = Arch("hexagon");
-    pub const mips: Arch<'static> = Arch("mips");
-    pub const mips64: Arch<'static> = Arch("mips64");
-    pub const msp430: Arch<'static> = Arch("msp430");
-    pub const nvptx64: Arch<'static> = Arch("nvptx64");
-    pub const powerpc: Arch<'static> = Arch("powerpc");
-    pub const powerpc64: Arch<'static> = Arch("powerpc64");
-    pub const riscv32: Arch<'static> = Arch("riscv32");
-    pub const riscv64: Arch<'static> = Arch("riscv64");
-    pub const s390x: Arch<'static> = Arch("s390x");
-    pub const sparc: Arch<'static> = Arch("sparc");
-    pub const sparc64: Arch<'static> = Arch("sparc64");
-    pub const wasm32: Arch<'static> = Arch("wasm32");
-    pub const wasm64: Arch<'static> = Arch("wasm64");
-    pub const x86: Arch<'static> = Arch("x86");
-    pub const x86_64: Arch<'static> = Arch("x86_64");
+impl super::Arch {
+    pub const aarch64: Arch = Arch::new_const("aarch64");
+    pub const arm: Arch = Arch::new_const("arm");
+    pub const avr: Arch = Arch::new_const("avr");
+    pub const hexagon: Arch = Arch::new_const("hexagon");
+    pub const mips: Arch = Arch::new_const("mips");
+    pub const mips64: Arch = Arch::new_const("mips64");
+    pub const msp430: Arch = Arch::new_const("msp430");
+    pub const nvptx64: Arch = Arch::new_const("nvptx64");
+    pub const powerpc: Arch = Arch::new_const("powerpc");
+    pub const powerpc64: Arch = Arch::new_const("powerpc64");
+    pub const riscv32: Arch = Arch::new_const("riscv32");
+    pub const riscv64: Arch = Arch::new_const("riscv64");
+    pub const s390x: Arch = Arch::new_const("s390x");
+    pub const sparc: Arch = Arch::new_const("sparc");
+    pub const sparc64: Arch = Arch::new_const("sparc64");
+    pub const wasm32: Arch = Arch::new_const("wasm32");
+    pub const wasm64: Arch = Arch::new_const("wasm64");
+    pub const x86: Arch = Arch::new_const("x86");
+    pub const x86_64: Arch = Arch::new_const("x86_64");
 }
 
-impl<'a> super::Vendor<'a> {
-    pub const apple: Vendor<'static> = Vendor("apple");
-    pub const fortanix: Vendor<'static> = Vendor("fortanix");
-    pub const nvidia: Vendor<'static> = Vendor("nvidia");
-    pub const pc: Vendor<'static> = Vendor("pc");
-    pub const sony: Vendor<'static> = Vendor("sony");
-    pub const sun: Vendor<'static> = Vendor("sun");
-    pub const unknown: Vendor<'static> = Vendor("unknown");
-    pub const uwp: Vendor<'static> = Vendor("uwp");
-    pub const wrs: Vendor<'static> = Vendor("wrs");
+impl super::Vendor {
+    pub const apple: Vendor = Vendor::new_const("apple");
+    pub const fortanix: Vendor = Vendor::new_const("fortanix");
+    pub const nvidia: Vendor = Vendor::new_const("nvidia");
+    pub const pc: Vendor = Vendor::new_const("pc");
+    pub const sony: Vendor = Vendor::new_const("sony");
+    pub const sun: Vendor = Vendor::new_const("sun");
+    pub const unknown: Vendor = Vendor::new_const("unknown");
+    pub const uwp: Vendor = Vendor::new_const("uwp");
+    pub const wrs: Vendor = Vendor::new_const("wrs");
 }
 
-impl<'a> super::Os<'a> {
-    pub const android: Os<'static> = Os("android");
-    pub const cuda: Os<'static> = Os("cuda");
-    pub const dragonfly: Os<'static> = Os("dragonfly");
-    pub const emscripten: Os<'static> = Os("emscripten");
-    pub const freebsd: Os<'static> = Os("freebsd");
-    pub const fuchsia: Os<'static> = Os("fuchsia");
-    pub const haiku: Os<'static> = Os("haiku");
-    pub const hermit: Os<'static> = Os("hermit");
-    pub const illumos: Os<'static> = Os("illumos");
-    pub const ios: Os<'static> = Os("ios");
-    pub const l4re: Os<'static> = Os("l4re");
-    pub const linux: Os<'static> = Os("linux");
-    pub const macos: Os<'static> = Os("macos");
-    pub const netbsd: Os<'static> = Os("netbsd");
-    pub const openbsd: Os<'static> = Os("openbsd");
-    pub const psp: Os<'static> = Os("psp");
-    pub const redox: Os<'static> = Os("redox");
-    pub const solaris: Os<'static> = Os("solaris");
-    pub const tvos: Os<'static> = Os("tvos");
-    pub const uefi: Os<'static> = Os("uefi");
-    pub const unknown: Os<'static> = Os("unknown");
-    pub const vxworks: Os<'static> = Os("vxworks");
-    pub const wasi: Os<'static> = Os("wasi");
-    pub const windows: Os<'static> = Os("windows");
+impl super::Os {
+    pub const android: Os = Os::new_const("android");
+    pub const cuda: Os = Os::new_const("cuda");
+    pub const dragonfly: Os = Os::new_const("dragonfly");
+    pub const emscripten: Os = Os::new_const("emscripten");
+    pub const freebsd: Os = Os::new_const("freebsd");
+    pub const fuchsia: Os = Os::new_const("fuchsia");
+    pub const haiku: Os = Os::new_const("haiku");
+    pub const hermit: Os = Os::new_const("hermit");
+    pub const illumos: Os = Os::new_const("illumos");
+    pub const ios: Os = Os::new_const("ios");
+    pub const l4re: Os = Os::new_const("l4re");
+    pub const linux: Os = Os::new_const("linux");
+    pub const macos: Os = Os::new_const("macos");
+    pub const netbsd: Os = Os::new_const("netbsd");
+    pub const openbsd: Os = Os::new_const("openbsd");
+    pub const psp: Os = Os::new_const("psp");
+    pub const redox: Os = Os::new_const("redox");
+    pub const solaris: Os = Os::new_const("solaris");
+    pub const tvos: Os = Os::new_const("tvos");
+    pub const uefi: Os = Os::new_const("uefi");
+    pub const unknown: Os = Os::new_const("unknown");
+    pub const vxworks: Os = Os::new_const("vxworks");
+    pub const wasi: Os = Os::new_const("wasi");
+    pub const windows: Os = Os::new_const("windows");
 }
 
-impl<'a> super::Env<'a> {
-    pub const eabihf: Env<'static> = Env("eabihf");
-    pub const gnu: Env<'static> = Env("gnu");
-    pub const gnueabihf: Env<'static> = Env("gnueabihf");
-    pub const msvc: Env<'static> = Env("msvc");
-    pub const musl: Env<'static> = Env("musl");
-    pub const relibc: Env<'static> = Env("relibc");
-    pub const sgx: Env<'static> = Env("sgx");
-    pub const uclibc: Env<'static> = Env("uclibc");
+impl super::Env {
+    pub const eabihf: Env = Env::new_const("eabihf");
+    pub const gnu: Env = Env::new_const("gnu");
+    pub const gnueabihf: Env = Env::new_const("gnueabihf");
+    pub const msvc: Env = Env::new_const("msvc");
+    pub const musl: Env = Env::new_const("musl");
+    pub const relibc: Env = Env::new_const("relibc");
+    pub const sgx: Env = Env::new_const("sgx");
+    pub const uclibc: Env = Env::new_const("uclibc");
 }

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -77,7 +77,7 @@ fn real_main() -> Result<(), String> {
     out.push_str(
         "
 
-        pub const ALL_BUILTINS: &[TargetInfo<'static>] = &[
+        pub const ALL_BUILTINS: &[TargetInfo] = &[
 ",
     );
 
@@ -191,7 +191,7 @@ fn real_main() -> Result<(), String> {
         writeln!(
             out,
             "    TargetInfo {{
-        triple: \"{triple}\",
+        triple: Triple::new_const(\"{triple}\"),
         os: {os},
         arch: Arch::{arch},
         env: {env},
@@ -243,12 +243,12 @@ fn real_main() -> Result<(), String> {
 }
 
 fn write_impls(out: &mut String, typ: &'static str, builtins: Vec<String>) {
-    writeln!(out, "\nimpl<'a> super::{}<'a> {{", typ).unwrap();
+    writeln!(out, "\nimpl super::{} {{", typ).unwrap();
 
     for thing in builtins {
         writeln!(
             out,
-            "pub const {}: {}<'static> = {}(\"{}\");",
+            "pub const {}: {} = {}::new_const(\"{}\");",
             thing, typ, typ, thing
         )
         .unwrap();


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This may let users of `TargetInfo` skip using lifetime params,
while still allowing creation at compile time using string literals.

For convenience, I've also added a `Triple` newtype wrapper, as well as
implemented a number of methods on all the newtype wrappers (including
the existing ones).

### Related Issues

Closes #30.
