### PR TITLE
update builtin targets to Rust 1.54.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["target-lexicon"]
 
 [dependencies]
 smallvec = "1.6"
-target-lexicon = { version = "0.12.1", optional = true }
+target-lexicon = { version = "0.12.2", optional = true }
 
 [dev-dependencies]
 difference = "2.0"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -69,7 +69,7 @@ impl TargetMatcher for targ::TargetInfo {
             PointerWidth(w) => *w == self.pointer_width,
             Vendor(ven) => match &self.vendor {
                 Some(v) => ven == v,
-                None => ven.0 == "unknown",
+                None => ven == &targ::Vendor::unknown,
             },
         }
     }
@@ -85,12 +85,12 @@ impl TargetMatcher for target_lexicon::Triple {
 
         match tp {
             Arch(arch) => {
-                if arch.0 == "x86" {
+                if arch == &targ::Arch::x86 {
                     matches!(self.architecture, Architecture::X86_32(_))
-                } else if arch.0 == "wasm32" {
+                } else if arch == &targ::Arch::wasm32 {
                     self.architecture == Architecture::Wasm32
                         || self.architecture == Architecture::Asmjs
-                } else if arch.0 == "arm" {
+                } else if arch == &targ::Arch::arm {
                     matches!(self.architecture, Architecture::Arm(_))
                 } else {
                     match arch.0.parse::<Architecture>() {
@@ -120,23 +120,23 @@ impl TargetMatcher for target_lexicon::Triple {
             Env(env) => {
                 // The environment is implied by some operating systems
                 match self.operating_system {
-                    OperatingSystem::Redox => env.0 == "relibc",
-                    OperatingSystem::VxWorks => env.0 == "gnu",
+                    OperatingSystem::Redox => env == &targ::Env::relibc,
+                    OperatingSystem::VxWorks => env == &targ::Env::gnu,
                     OperatingSystem::Freebsd => match self.architecture {
                         Architecture::Arm(ArmArchitecture::Armv6)
-                        | Architecture::Arm(ArmArchitecture::Armv7) => env.0 == "gnueabihf",
+                        | Architecture::Arm(ArmArchitecture::Armv7) => env == &targ::Env::gnueabihf,
                         _ => env.0.is_empty(),
                     },
                     OperatingSystem::Netbsd => match self.architecture {
                         Architecture::Arm(ArmArchitecture::Armv6)
-                        | Architecture::Arm(ArmArchitecture::Armv7) => env.0 == "eabihf",
+                        | Architecture::Arm(ArmArchitecture::Armv7) => env == &targ::Env::eabihf,
                         _ => env.0.is_empty(),
                     },
                     OperatingSystem::None_
                     | OperatingSystem::Cloudabi
                     | OperatingSystem::Hermit
                     | OperatingSystem::Ios => match self.environment {
-                        Environment::LinuxKernel => env.0 == "gnu",
+                        Environment::LinuxKernel => env == &targ::Env::gnu,
                         _ => env.0.is_empty(),
                     },
                     _ => {
@@ -153,7 +153,7 @@ impl TargetMatcher for target_lexicon::Triple {
                             match env.0.parse::<Environment>() {
                                 Ok(e) => {
                                     // Rustc shortens multiple "gnu*" environments to just "gnu"
-                                    if env.0 == "gnu" {
+                                    if env == &targ::Env::gnu {
                                         match self.environment {
                                             Environment::Gnu
                                             | Environment::Gnuabi64
@@ -175,7 +175,7 @@ impl TargetMatcher for target_lexicon::Triple {
                                             }
                                             _ => false,
                                         }
-                                    } else if env.0 == "musl" {
+                                    } else if env == &targ::Env::musl {
                                         matches!(
                                             self.environment,
                                             Environment::Musl
@@ -183,7 +183,7 @@ impl TargetMatcher for target_lexicon::Triple {
                                                 | Environment::Musleabihf
                                                 | Environment::Muslabi64
                                         )
-                                    } else if env.0 == "uclibc" {
+                                    } else if env == &targ::Env::uclibc {
                                         matches!(
                                             self.environment,
                                             Environment::Uclibc | Environment::Uclibceabi
@@ -239,17 +239,17 @@ impl TargetMatcher for target_lexicon::Triple {
             }
             Os(os) => match os.0.parse::<OperatingSystem>() {
                 Ok(o) => match self.environment {
-                    Environment::HermitKernel => os.0 == "hermit",
+                    Environment::HermitKernel => os == &targ::Os::hermit,
                     _ => self.operating_system == o,
                 },
                 Err(_) => {
                     // Handle special case for darwin/macos, where the triple is
                     // "darwin", but rustc identifies the OS as "macos"
-                    if os.0 == "macos" && self.operating_system == OperatingSystem::Darwin {
+                    if os == &targ::Os::macos && self.operating_system == OperatingSystem::Darwin {
                         true
                     } else {
                         // For android, the os is still linux, but the environment is android
-                        os.0 == "android"
+                        os == &targ::Os::android
                             && self.operating_system == OperatingSystem::Linux
                             && (self.environment == Environment::Android
                                 || self.environment == Environment::Androideabi)

--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -73,15 +73,9 @@ impl Expression {
                 "unix" | "windows" => {
                     err_if_val!();
 
-                    let fam = key.parse().map_err(|reason| ParseError {
-                        original: original.to_owned(),
-                        span,
-                        reason,
-                    })?;
-
                     InnerPredicate::Target(InnerTarget {
-                        which: Which::Family(fam),
-                        span: None,
+                        which: Which::Family,
+                        span: Some(span),
                     })
                 }
                 "test" => {
@@ -147,18 +141,7 @@ impl Expression {
                             return Ok(InnerPredicate::TargetFeature(vspan));
                         }
                         "os" => tp!(Os),
-                        "family" => {
-                            let fam = val.parse().map_err(|reason| ParseError {
-                                original: original.to_owned(),
-                                span,
-                                reason,
-                            })?;
-
-                            InnerTarget {
-                                which: Which::Family(fam),
-                                span: None,
-                            }
-                        }
+                        "family" => tp!(Family),
                         "env" => tp!(Env),
                         "endian" => InnerTarget {
                             which: Which::Endian(val.parse().map_err(|_err| ParseError {

--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -70,6 +70,9 @@ impl Expression {
                 // These are special cases in the cfg language that are
                 // semantically the same as `target_family = "<family>"`,
                 // so we just make them not special
+                // NOTE: other target families like "wasm" are NOT allowed
+                // as naked predicates; they must be specified through
+                // `target_family`
                 "unix" | "windows" => {
                     err_if_val!();
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -3,7 +3,8 @@ use std::borrow::Cow;
 
 mod builtins;
 
-/// A list of all of the [builtin](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/index.html#modules)
+/// A lis
+/// t of all of the [builtin](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/index.html#modules)
 /// targets known to rustc, as of 1.49.0
 pub use builtins::ALL_BUILTINS;
 
@@ -23,6 +24,12 @@ pub struct Vendor(pub Cow<'static, str>);
 /// sometimes isn't an actual operating system.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Os(pub Cow<'static, str>);
+
+/// The target family, which describes a set of targets grouped in some logical manner, typically by
+/// operating system. This includes values like `unix` and `windows`.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub struct Family(pub Cow<'static, str>);
 
 /// The "environment" field, which specifies an ABI environment on top of the
 /// operating system. In many configurations, this field is omitted, and the
@@ -73,6 +80,7 @@ field_impls!(Triple);
 field_impls!(Arch);
 field_impls!(Vendor);
 field_impls!(Os);
+field_impls!(Family);
 field_impls!(Env);
 
 macro_rules! target_enum {
@@ -132,17 +140,6 @@ target_enum! {
     pub enum Endian {
         big,
         little,
-    }
-}
-
-target_enum! {
-    /// All of the target families known to rustc
-    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    pub enum Family {
-        /// Everything that isn't windows, and has a family!
-        unix,
-        /// The lone wolf of target families.
-        windows,
     }
 }
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -3,9 +3,8 @@ use std::borrow::Cow;
 
 mod builtins;
 
-/// A lis
-/// t of all of the [builtin](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/index.html#modules)
-/// targets known to rustc, as of 1.49.0
+/// A list of all of the [builtin](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/index.html#modules)
+/// targets known to rustc, as of 1.54.0
 pub use builtins::ALL_BUILTINS;
 
 /// The unique identifier for a target.

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -27,7 +27,6 @@ pub struct Os(pub Cow<'static, str>);
 /// The target family, which describes a set of targets grouped in some logical manner, typically by
 /// operating system. This includes values like `unix` and `windows`.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[non_exhaustive]
 pub struct Family(pub Cow<'static, str>);
 
 /// The "environment" field, which specifies an ABI environment on top of the

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -195,7 +195,7 @@ pub fn get_builtin_target_by_triple(triple: &str) -> Option<&'static TargetInfo>
 /// versions.
 ///
 /// ```
-/// assert_eq!("1.53.0", cfg_expr::targets::rustc_version());
+/// assert_eq!("1.54.0", cfg_expr::targets::rustc_version());
 /// ```
 pub fn rustc_version() -> &'static str {
     builtins::RUSTC_VERSION

--- a/src/targets/builtins.rs
+++ b/src/targets/builtins.rs
@@ -1706,6 +1706,11 @@ impl super::Os {
     pub const windows: Os = Os::new_const("windows");
 }
 
+impl super::Family {
+    pub const unix: Family = Family::new_const("unix");
+    pub const windows: Family = Family::new_const("windows");
+}
+
 impl super::Env {
     pub const eabihf: Env = Env::new_const("eabihf");
     pub const gnu: Env = Env::new_const("gnu");

--- a/src/targets/builtins.rs
+++ b/src/targets/builtins.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 
-pub(crate) const RUSTC_VERSION: &str = "1.53.0";
+pub(crate) const RUSTC_VERSION: &str = "1.54.0";
 
 pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
@@ -521,6 +521,26 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         vendor: Some(Vendor::unknown),
         family: None,
         pointer_width: 16,
+        endian: Endian::little,
+    },
+    TargetInfo {
+        triple: Triple::new_const("bpfeb-unknown-none"),
+        os: None,
+        arch: Arch::bpf,
+        env: None,
+        vendor: Some(Vendor::unknown),
+        family: None,
+        pointer_width: 64,
+        endian: Endian::big,
+    },
+    TargetInfo {
+        triple: Triple::new_const("bpfel-unknown-none"),
+        os: None,
+        arch: Arch::bpf,
+        env: None,
+        vendor: Some(Vendor::unknown),
+        family: None,
+        pointer_width: 64,
         endian: Endian::little,
     },
     TargetInfo {
@@ -1329,7 +1349,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         arch: Arch::wasm32,
         env: None,
         vendor: Some(Vendor::unknown),
-        family: None,
+        family: Some(Family::wasm),
         pointer_width: 32,
         endian: Endian::little,
     },
@@ -1339,7 +1359,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         arch: Arch::wasm32,
         env: None,
         vendor: Some(Vendor::unknown),
-        family: None,
+        family: Some(Family::wasm),
         pointer_width: 32,
         endian: Endian::little,
     },
@@ -1349,7 +1369,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         arch: Arch::wasm64,
         env: None,
         vendor: Some(Vendor::unknown),
-        family: None,
+        family: Some(Family::wasm),
         pointer_width: 64,
         endian: Endian::little,
     },
@@ -1649,6 +1669,7 @@ impl super::Arch {
     pub const aarch64: Arch = Arch::new_const("aarch64");
     pub const arm: Arch = Arch::new_const("arm");
     pub const avr: Arch = Arch::new_const("avr");
+    pub const bpf: Arch = Arch::new_const("bpf");
     pub const hexagon: Arch = Arch::new_const("hexagon");
     pub const mips: Arch = Arch::new_const("mips");
     pub const mips64: Arch = Arch::new_const("mips64");
@@ -1708,6 +1729,7 @@ impl super::Os {
 
 impl super::Family {
     pub const unix: Family = Family::new_const("unix");
+    pub const wasm: Family = Family::new_const("wasm");
     pub const windows: Family = Family::new_const("windows");
 }
 

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -92,7 +92,9 @@ macro_rules! tg_match {
 
 #[test]
 fn target_family() {
-    let matches_any_family = Expression::parse("any(unix, target_family = \"windows\")").unwrap();
+    let matches_any_family =
+        Expression::parse("any(unix, target_family = \"windows\", target_family = \"wasm\")")
+            .unwrap();
     let impossible = Expression::parse("all(windows, target_family = \"unix\")").unwrap();
 
     for target in all {
@@ -228,6 +230,24 @@ fn complex() {
     // Should *not* match x86_64 windows or android
     assert!(!complex.eval(|pred| tg_match!(pred, windows_msvc)));
     assert!(!complex.eval(|pred| tg_match!(pred, android)));
+}
+
+#[test]
+fn wasm_family() {
+    let wasm = Expression::parse(r#"cfg(target_family = "wasm")"#).unwrap();
+
+    let wasm32_unknown = Target::make("wasm32-unknown-unknown");
+    let wasm32_emscripten = Target::make("wasm32-unknown-emscripten");
+    let wasm32_wasi = Target::make("wasm32-wasi");
+    let wasm64_unknown = Target::make("wasm64-unknown-unknown");
+
+    // wasm32_unknown, wasm32_wasi and wasm64_unknown match.
+    assert!(wasm.eval(|pred| tg_match!(pred, wasm32_unknown)));
+    assert!(wasm.eval(|pred| tg_match!(pred, wasm32_wasi)));
+    assert!(wasm.eval(|pred| tg_match!(pred, wasm64_unknown)));
+
+    // wasm32_emscripten does not match.
+    assert!(!wasm.eval(|pred| tg_match!(pred, wasm32_emscripten)));
 }
 
 #[test]

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -89,6 +89,7 @@ fn real_main() -> Result<(), String> {
     let mut vendors: Vec<String> = Vec::new();
     let mut oses: Vec<String> = Vec::new();
     let mut envs: Vec<String> = Vec::new();
+    let mut families: Vec<String> = Vec::new();
 
     for target in targets.lines() {
         let output = Command::new(&rustc)
@@ -187,6 +188,7 @@ fn real_main() -> Result<(), String> {
         insert(vendor, &mut vendors);
         insert(os, &mut oses);
         insert(env, &mut envs);
+        insert(family, &mut families);
 
         writeln!(
             out,
@@ -225,6 +227,7 @@ fn real_main() -> Result<(), String> {
     write_impls(&mut out, "Arch", arches);
     write_impls(&mut out, "Vendor", vendors);
     write_impls(&mut out, "Os", oses);
+    write_impls(&mut out, "Family", families);
     write_impls(&mut out, "Env", envs);
 
     std::fs::write("src/targets/builtins.rs", out)


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This includes several changes:

1. Rust 1.54 introduces the new WASM target family. More target families
might be added in the future, so make this enum open-ended like Arch, Os
and others.
2. Use builtin constants for target-lexicon matching.
3. Update the builtin targets and target-lexicon, and handle the new bpf
architectures and wasm family.
