### PR TITLE
Add support for `abi` if it is present

### DIFF
--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -144,6 +144,7 @@ impl Expression {
                     }
 
                     let tp = match &target_key[7..] {
+                        "abi" => tp!(Abi),
                         "arch" => tp!(Arch),
                         "feature" => {
                             if val.is_empty() {

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -11,6 +11,10 @@ pub use builtins::ALL_BUILTINS;
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Triple(pub Cow<'static, str>);
 
+/// The "abi" field
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Abi(pub Cow<'static, str>);
+
 /// The "architecture" field
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Arch(pub Cow<'static, str>);
@@ -79,6 +83,7 @@ macro_rules! field_impls {
 }
 
 field_impls!(Triple);
+field_impls!(Abi);
 field_impls!(Arch);
 field_impls!(Vendor);
 field_impls!(Os);
@@ -316,6 +321,9 @@ pub struct TargetInfo {
     /// [target_os](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os)
     /// predicate.
     pub os: Option<Os>,
+    /// The target's ABI, if any. Used by the
+    /// [target_abi](https://github.com/rust-lang/rust/issues/80970) predicate.
+    pub abi: Option<Abi>,
     /// The target's CPU architecture. Used by the
     /// [target_arch](https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch)
     /// predicate.

--- a/src/targets/builtins.rs
+++ b/src/targets/builtins.rs
@@ -16,6 +16,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-apple-darwin"),
         os: Some(Os::macos),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -28,6 +29,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-apple-ios"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -40,6 +42,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-apple-ios-macabi"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -52,6 +55,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-apple-ios-sim"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -64,6 +68,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-apple-tvos"),
         os: Some(Os::tvos),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -76,6 +81,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-apple-watchos-sim"),
         os: Some(Os::watchos),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -88,6 +94,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-fuchsia"),
         os: Some(Os::fuchsia),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -100,6 +107,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-kmc-solid_asp3"),
         os: Some(Os::solid_asp3),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::kmc),
@@ -112,6 +120,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-linux-android"),
         os: Some(Os::android),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -124,6 +133,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-nintendo-switch-freestanding"),
         os: Some(Os::horizon),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -136,6 +146,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-pc-windows-gnullvm"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::pc),
@@ -148,6 +159,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-pc-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::msvc),
         vendor: Some(Vendor::pc),
@@ -160,6 +172,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -172,6 +185,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-hermit"),
         os: Some(Os::hermit),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -184,6 +198,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -196,6 +211,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-linux-gnu_ilp32"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -208,6 +224,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -220,6 +237,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-netbsd"),
         os: Some(Os::netbsd),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -232,6 +250,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-none"),
         os: None,
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -244,6 +263,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-none-softfloat"),
         os: None,
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -256,6 +276,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-openbsd"),
         os: Some(Os::openbsd),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -268,6 +289,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-redox"),
         os: Some(Os::redox),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::relibc),
         vendor: Some(Vendor::unknown),
@@ -280,6 +302,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-unknown-uefi"),
         os: Some(Os::uefi),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -292,6 +315,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-uwp-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::msvc),
         vendor: Some(Vendor::uwp),
@@ -304,6 +328,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64-wrs-vxworks"),
         os: Some(Os::vxworks),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::wrs),
@@ -316,6 +341,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64_be-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -328,6 +354,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("aarch64_be-unknown-linux-gnu_ilp32"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::aarch64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -340,6 +367,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("arm-linux-androideabi"),
         os: Some(Os::android),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -352,6 +380,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("arm-unknown-linux-gnueabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -364,6 +393,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("arm-unknown-linux-gnueabihf"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -376,6 +406,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("arm-unknown-linux-musleabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -388,6 +419,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("arm-unknown-linux-musleabihf"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -400,6 +432,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("arm64_32-apple-watchos"),
         os: Some(Os::watchos),
+        abi: None,
         arch: Arch::aarch64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -424,6 +457,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armebv7r-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -436,6 +470,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armebv7r-none-eabihf"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -460,6 +495,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv4t-unknown-linux-gnueabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -472,6 +508,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv5te-unknown-linux-gnueabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -484,6 +521,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv5te-unknown-linux-musleabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -496,6 +534,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv5te-unknown-linux-uclibceabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::uclibc),
         vendor: Some(Vendor::unknown),
@@ -508,6 +547,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv6-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnueabihf),
         vendor: Some(Vendor::unknown),
@@ -520,6 +560,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv6-unknown-netbsd-eabihf"),
         os: Some(Os::netbsd),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::eabihf),
         vendor: Some(Vendor::unknown),
@@ -532,6 +573,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv6k-nintendo-3ds"),
         os: Some(Os::horizon),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::newlib),
         vendor: Some(Vendor::nintendo),
@@ -544,6 +586,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-apple-ios"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::apple),
@@ -556,6 +599,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-linux-androideabi"),
         os: Some(Os::android),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -568,6 +612,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnueabihf),
         vendor: Some(Vendor::unknown),
@@ -580,6 +625,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-linux-gnueabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -592,6 +638,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-linux-gnueabihf"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -604,6 +651,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-linux-musleabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -616,6 +664,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-linux-musleabihf"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -628,6 +677,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-linux-uclibceabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::uclibc),
         vendor: Some(Vendor::unknown),
@@ -640,6 +690,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-linux-uclibceabihf"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::uclibc),
         vendor: Some(Vendor::unknown),
@@ -652,6 +703,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-netbsd-eabihf"),
         os: Some(Os::netbsd),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::eabihf),
         vendor: Some(Vendor::unknown),
@@ -664,6 +716,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7-wrs-vxworks-eabihf"),
         os: Some(Os::vxworks),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::wrs),
@@ -676,6 +729,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7a-kmc-solid_asp3-eabi"),
         os: Some(Os::solid_asp3),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::kmc),
@@ -688,6 +742,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7a-kmc-solid_asp3-eabihf"),
         os: Some(Os::solid_asp3),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::kmc),
@@ -700,6 +755,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7a-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -712,6 +768,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7a-none-eabihf"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -724,6 +781,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7k-apple-watchos"),
         os: Some(Os::watchos),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::apple),
@@ -736,6 +794,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7r-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -748,6 +807,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7r-none-eabihf"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -760,6 +820,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv7s-apple-ios"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::apple),
@@ -772,6 +833,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("asmjs-unknown-emscripten"),
         os: Some(Os::emscripten),
+        abi: None,
         arch: Arch::wasm32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -784,6 +846,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("avr-unknown-gnu-atmega328"),
         os: None,
+        abi: None,
         arch: Arch::avr,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -796,6 +859,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("bpfeb-unknown-none"),
         os: None,
+        abi: None,
         arch: Arch::bpf,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -808,6 +872,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("bpfel-unknown-none"),
         os: None,
+        abi: None,
         arch: Arch::bpf,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -820,6 +885,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("hexagon-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::hexagon,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -832,6 +898,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i386-apple-ios"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::apple),
@@ -844,6 +911,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i586-pc-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::msvc),
         vendor: Some(Vendor::pc),
@@ -856,6 +924,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i586-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -868,6 +937,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i586-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -880,6 +950,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-apple-darwin"),
         os: Some(Os::macos),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::apple),
@@ -892,6 +963,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-linux-android"),
         os: Some(Os::android),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -904,6 +976,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-pc-windows-gnu"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::gnu),
         vendor: Some(Vendor::pc),
@@ -916,6 +989,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-pc-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::msvc),
         vendor: Some(Vendor::pc),
@@ -928,6 +1002,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -940,6 +1015,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-unknown-haiku"),
         os: Some(Os::haiku),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -952,6 +1028,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -964,6 +1041,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -976,6 +1054,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-unknown-netbsd"),
         os: Some(Os::netbsd),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -988,6 +1067,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-unknown-openbsd"),
         os: Some(Os::openbsd),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1000,6 +1080,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-unknown-uefi"),
         os: Some(Os::uefi),
+        abi: None,
         arch: Arch::x86,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1012,6 +1093,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-uwp-windows-gnu"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::gnu),
         vendor: Some(Vendor::uwp),
@@ -1024,6 +1106,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-uwp-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::msvc),
         vendor: Some(Vendor::uwp),
@@ -1036,6 +1119,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("i686-wrs-vxworks"),
         os: Some(Os::vxworks),
+        abi: None,
         arch: Arch::x86,
         env: Some(Env::gnu),
         vendor: Some(Vendor::wrs),
@@ -1048,6 +1132,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("m68k-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::m68k,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1060,6 +1145,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1072,6 +1158,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1084,6 +1171,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips-unknown-linux-uclibc"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::uclibc),
         vendor: Some(Vendor::unknown),
@@ -1096,6 +1184,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips64-openwrt-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1108,6 +1197,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips64-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1120,6 +1210,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips64-unknown-linux-muslabi64"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1132,6 +1223,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips64el-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1144,6 +1236,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mips64el-unknown-linux-muslabi64"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1156,6 +1249,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsel-sony-psp"),
         os: Some(Os::psp),
+        abi: None,
         arch: Arch::mips,
         env: None,
         vendor: Some(Vendor::sony),
@@ -1168,6 +1262,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsel-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1180,6 +1275,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsel-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1192,6 +1288,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsel-unknown-linux-uclibc"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::uclibc),
         vendor: Some(Vendor::unknown),
@@ -1204,6 +1301,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsel-unknown-none"),
         os: None,
+        abi: None,
         arch: Arch::mips,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1216,6 +1314,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsisa32r6-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1228,6 +1327,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsisa32r6el-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1240,6 +1340,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsisa64r6-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1252,6 +1353,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("mipsisa64r6el-unknown-linux-gnuabi64"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::mips64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1264,6 +1366,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("msp430-none-elf"),
         os: None,
+        abi: None,
         arch: Arch::msp430,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1276,6 +1379,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("nvptx64-nvidia-cuda"),
         os: Some(Os::cuda),
+        abi: None,
         arch: Arch::nvptx64,
         env: None,
         vendor: Some(Vendor::nvidia),
@@ -1288,6 +1392,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::powerpc,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1300,6 +1405,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::powerpc,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1312,6 +1418,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-unknown-linux-gnuspe"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::powerpc,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1324,6 +1431,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::powerpc,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1336,6 +1444,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-unknown-netbsd"),
         os: Some(Os::netbsd),
+        abi: None,
         arch: Arch::powerpc,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1348,6 +1457,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-unknown-openbsd"),
         os: Some(Os::openbsd),
+        abi: None,
         arch: Arch::powerpc,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1360,6 +1470,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-wrs-vxworks"),
         os: Some(Os::vxworks),
+        abi: None,
         arch: Arch::powerpc,
         env: Some(Env::gnu),
         vendor: Some(Vendor::wrs),
@@ -1372,6 +1483,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc-wrs-vxworks-spe"),
         os: Some(Os::vxworks),
+        abi: None,
         arch: Arch::powerpc,
         env: Some(Env::gnu),
         vendor: Some(Vendor::wrs),
@@ -1384,6 +1496,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::powerpc64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1396,6 +1509,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::powerpc64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1408,6 +1522,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::powerpc64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1432,6 +1547,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64-wrs-vxworks"),
         os: Some(Os::vxworks),
+        abi: None,
         arch: Arch::powerpc64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::wrs),
@@ -1444,6 +1560,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64le-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::powerpc64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1456,6 +1573,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64le-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::powerpc64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1468,6 +1586,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64le-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::powerpc64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1480,6 +1599,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32gc-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::riscv32,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1492,6 +1612,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32gc-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::riscv32,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1504,6 +1625,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32i-unknown-none-elf"),
         os: None,
+        abi: None,
         arch: Arch::riscv32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1516,6 +1638,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32im-unknown-none-elf"),
         os: None,
+        abi: None,
         arch: Arch::riscv32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1528,6 +1651,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32imac-unknown-none-elf"),
         os: None,
+        abi: None,
         arch: Arch::riscv32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1540,6 +1664,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32imac-unknown-xous-elf"),
         os: Some(Os::xous),
+        abi: None,
         arch: Arch::riscv32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1552,6 +1677,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32imc-esp-espidf"),
         os: Some(Os::espidf),
+        abi: None,
         arch: Arch::riscv32,
         env: Some(Env::newlib),
         vendor: Some(Vendor::espressif),
@@ -1564,6 +1690,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv32imc-unknown-none-elf"),
         os: None,
+        abi: None,
         arch: Arch::riscv32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1576,6 +1703,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv64gc-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::riscv64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1588,6 +1716,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv64gc-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::riscv64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1600,6 +1729,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv64gc-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::riscv64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1612,6 +1742,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv64gc-unknown-none-elf"),
         os: None,
+        abi: None,
         arch: Arch::riscv64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1636,6 +1767,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv64imac-unknown-none-elf"),
         os: None,
+        abi: None,
         arch: Arch::riscv64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1648,6 +1780,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("s390x-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::s390x,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1660,6 +1793,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("s390x-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::s390x,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1672,6 +1806,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("sparc-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::sparc,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1684,6 +1819,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("sparc64-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::sparc64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1696,6 +1832,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("sparc64-unknown-netbsd"),
         os: Some(Os::netbsd),
+        abi: None,
         arch: Arch::sparc64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1708,6 +1845,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("sparc64-unknown-openbsd"),
         os: Some(Os::openbsd),
+        abi: None,
         arch: Arch::sparc64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1720,6 +1858,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("sparcv9-sun-solaris"),
         os: Some(Os::solaris),
+        abi: None,
         arch: Arch::sparc64,
         env: None,
         vendor: Some(Vendor::sun),
@@ -1732,6 +1871,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv4t-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1744,6 +1884,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv6m-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1756,6 +1897,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7a-pc-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::msvc),
         vendor: Some(Vendor::pc),
@@ -1768,6 +1910,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7a-uwp-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::msvc),
         vendor: Some(Vendor::uwp),
@@ -1780,6 +1923,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7em-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1792,6 +1936,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7em-none-eabihf"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1804,6 +1949,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7m-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1816,6 +1962,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7neon-linux-androideabi"),
         os: Some(Os::android),
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1828,6 +1975,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7neon-unknown-linux-gnueabihf"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -1840,6 +1988,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv7neon-unknown-linux-musleabihf"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -1852,6 +2001,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv8m.base-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1864,6 +2014,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv8m.main-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1876,6 +2027,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("thumbv8m.main-none-eabihf"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1888,6 +2040,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("wasm32-unknown-emscripten"),
         os: Some(Os::emscripten),
+        abi: None,
         arch: Arch::wasm32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1900,6 +2053,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("wasm32-unknown-unknown"),
         os: Some(Os::unknown),
+        abi: None,
         arch: Arch::wasm32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1912,6 +2066,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("wasm32-wasi"),
         os: Some(Os::wasi),
+        abi: None,
         arch: Arch::wasm32,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1924,6 +2079,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("wasm64-unknown-unknown"),
         os: Some(Os::unknown),
+        abi: None,
         arch: Arch::wasm64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1936,6 +2092,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-apple-darwin"),
         os: Some(Os::macos),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -1948,6 +2105,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-apple-ios"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -1960,6 +2118,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-apple-ios-macabi"),
         os: Some(Os::ios),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -1972,6 +2131,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-apple-tvos"),
         os: Some(Os::tvos),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -1984,6 +2144,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-apple-watchos-sim"),
         os: Some(Os::watchos),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::apple),
@@ -1996,6 +2157,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-fortanix-unknown-sgx"),
         os: Some(Os::unknown),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::sgx),
         vendor: Some(Vendor::fortanix),
@@ -2008,6 +2170,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-fuchsia"),
         os: Some(Os::fuchsia),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2020,6 +2183,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-linux-android"),
         os: Some(Os::android),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2032,6 +2196,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-pc-solaris"),
         os: Some(Os::solaris),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::pc),
@@ -2044,6 +2209,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-pc-windows-gnu"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::pc),
@@ -2056,6 +2222,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-pc-windows-gnullvm"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::pc),
@@ -2068,6 +2235,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-pc-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::msvc),
         vendor: Some(Vendor::pc),
@@ -2080,6 +2248,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-sun-solaris"),
         os: Some(Os::solaris),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::sun),
@@ -2092,6 +2261,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-dragonfly"),
         os: Some(Os::dragonfly),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2104,6 +2274,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-freebsd"),
         os: Some(Os::freebsd),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2116,6 +2287,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-haiku"),
         os: Some(Os::haiku),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2128,6 +2300,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-hermit"),
         os: Some(Os::hermit),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2140,6 +2313,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-illumos"),
         os: Some(Os::illumos),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2152,6 +2326,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-l4re-uclibc"),
         os: Some(Os::l4re),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::uclibc),
         vendor: Some(Vendor::unknown),
@@ -2164,6 +2339,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-linux-gnu"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -2176,6 +2352,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-linux-gnux32"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -2188,6 +2365,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-linux-musl"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::musl),
         vendor: Some(Vendor::unknown),
@@ -2200,6 +2378,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-netbsd"),
         os: Some(Os::netbsd),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2212,6 +2391,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-none"),
         os: None,
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2224,6 +2404,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-none-linuxkernel"),
         os: None,
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -2236,6 +2417,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-openbsd"),
         os: Some(Os::openbsd),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2248,6 +2430,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-redox"),
         os: Some(Os::redox),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::relibc),
         vendor: Some(Vendor::unknown),
@@ -2260,6 +2443,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-unknown-uefi"),
         os: Some(Os::uefi),
+        abi: None,
         arch: Arch::x86_64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -2272,6 +2456,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-uwp-windows-gnu"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::uwp),
@@ -2284,6 +2469,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-uwp-windows-msvc"),
         os: Some(Os::windows),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::msvc),
         vendor: Some(Vendor::uwp),
@@ -2296,6 +2482,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("x86_64-wrs-vxworks"),
         os: Some(Os::vxworks),
+        abi: None,
         arch: Arch::x86_64,
         env: Some(Env::gnu),
         vendor: Some(Vendor::wrs),
@@ -2306,6 +2493,8 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         panic: Panic::unwind,
     },
 ];
+
+impl super::Abi {}
 
 impl super::Arch {
     pub const aarch64: Arch = Arch::new_const("aarch64");

--- a/src/targets/builtins.rs
+++ b/src/targets/builtins.rs
@@ -445,6 +445,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armeb-unknown-linux-gnueabi"),
         os: Some(Os::linux),
+        abi: None,
         arch: Arch::arm,
         env: Some(Env::gnu),
         vendor: Some(Vendor::unknown),
@@ -483,6 +484,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("armv4t-none-eabi"),
         os: None,
+        abi: None,
         arch: Arch::arm,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1535,6 +1537,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("powerpc64-unknown-openbsd"),
         os: Some(Os::openbsd),
+        abi: None,
         arch: Arch::powerpc64,
         env: None,
         vendor: Some(Vendor::unknown),
@@ -1755,6 +1758,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
         triple: Triple::new_const("riscv64gc-unknown-openbsd"),
         os: Some(Os::openbsd),
+        abi: None,
         arch: Arch::riscv64,
         env: None,
         vendor: Some(Vendor::unknown),


### PR DESCRIPTION
- Parse target_abi if it's present even though it's unstable
- Add missing abi to new builtins

I wasn't able to push changes to #52 so opened a new PR.

Closes: #52