### PR TITLE
Fix target_os = "none" parsing

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -79,7 +79,12 @@ impl TargetMatcher for targ::TargetInfo {
             },
             Family(fam) => self.families.contains(fam),
             HasAtomic(has_atomic) => self.has_atomics.contains(*has_atomic),
-            Os(os) => Some(os) == self.os.as_ref(),
+            Os(os) => match &self.os {
+                Some(self_os) => os == self_os,
+                // os = "none" means it should be matched against None. Note that this is different
+                // from "env" above.
+                None => os.as_str() == "none",
+            },
             PointerWidth(w) => *w == self.pointer_width,
             Vendor(ven) => match &self.vendor {
                 Some(v) => ven == v,

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -251,6 +251,12 @@ fn complex() {
     // Should *not* match x86_64 windows or android
     assert!(!complex.eval(|pred| tg_match!(pred, windows_msvc)));
     assert!(!complex.eval(|pred| tg_match!(pred, android)));
+
+    // Ensure that target_os = "none" matches against Os == None.
+    let complex = Expression::parse(r#"all(target_os="none")"#).unwrap();
+    let armebv7r_none_eabi = Target::make("armebv7r-none-eabi");
+    assert!(!complex.eval(|pred| tg_match!(pred, linux_gnu)));
+    assert!(complex.eval(|pred| tg_match!(pred, armebv7r_none_eabi)));
 }
 
 #[test]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

`target_os = "none"` should be understood to be None. I verified that Cargo parses it this way.

I originally encountered this with ahash 0.8.3, which [sets in its Cargo.toml](https://github.com/tkaitchuck/aHash/blob/f9acd508bd89e7c5b2877a9510098100f9018d64/Cargo.toml#L84-L85):

```
cfg(not(all(target_arch = "arm", target_os = "none")))
```
