### PR TITLE
Bump target-lexicon to 0.12.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ targets = ["target-lexicon"]
 
 [dependencies]
 smallvec = "1.8"
-target-lexicon = { version = "0.12.5", optional = true }
+target-lexicon = { version = "0.12.6", optional = true }
 
 [dev-dependencies]
 similar-asserts = "1.1"


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I ~~have read and~~ agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This crate fails to compile using the current minimum required version of target-lexicon as it does not include the `Aix` variant used within this crate.
