### PR TITLE
Update to 1.72.0 targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        toolchain: [1.58.0, stable]
+        toolchain: [1.70.0, stable]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#64](https://github.com/EmbarkStudios/cfg-expr/pull/64) updated the builtin target list to 1.72.0. It also changed the MSRV to 1.70.0.
+
 ## [0.15.4] - 2023-07-28
 ### Changed
 - [PR#62](https://github.com/EmbarkStudios/cfg-expr/pull/62) updated the builtin target list to 1.71.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-rust-version = "1.58.0"
+rust-version = "1.70.0"
 documentation = "https://docs.rs/cfg-expr"
 homepage = "https://github.com/EmbarkStudios/cfg-expr"
 keywords = ["cargo", "rustc", "cfg"]
@@ -24,7 +24,7 @@ targets = ["target-lexicon"]
 
 [dependencies]
 smallvec = "1.8"
-target-lexicon = { version = "0.12.5", optional = true }
+target-lexicon = { version = "0.12.11", optional = true }
 
 [dev-dependencies]
 similar-asserts = "1.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `⚙️ cfg-expr`
 
-**A parser and evaluator for Rust `cfg()` expressions. Builtin targets as of [Rust 1.69.0](https://forge.rust-lang.org/release/platform-support.html) are supported.**
+**A parser and evaluator for Rust `cfg()` expressions. Builtin targets as of [Rust 1.72.0](https://forge.rust-lang.org/release/platform-support.html) are supported.**
 
 [![Build Status](https://github.com/EmbarkStudios/cfg-expr/workflows/CI/badge.svg)](https://github.com/EmbarkStudios/cfg-expr/actions?workflow=CI)
 [![Crates.io](https://img.shields.io/crates/v/cfg-expr.svg)](https://crates.io/crates/cfg-expr)
@@ -22,7 +22,7 @@
 
 `cfg-expr` is a crate that can be used to parse and evaluate Rust `cfg()` expressions, both as declarable in Rust code itself, as well in cargo manifests' `[target.'cfg()'.dependencies]` sections.
 
-It contains a list of all builtin targets known to rustc as of `1.66.0` that can be used to determine if a particular cfg expression is satisfiable.
+It contains a list of all builtin targets known to rustc as of `1.72.0` that can be used to determine if a particular cfg expression is satisfiable.
 
 ```rust
 use cfg_expr::{targets::get_builtin_target_by_triple, Expression, Predicate};

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -372,7 +372,7 @@ pub fn get_builtin_target_by_triple(triple: &str) -> Option<&'static TargetInfo>
 /// versions.
 ///
 /// ```
-/// assert_eq!("1.71.0", cfg_expr::targets::rustc_version());
+/// assert_eq!("1.72.0", cfg_expr::targets::rustc_version());
 /// ```
 pub fn rustc_version() -> &'static str {
     builtins::RUSTC_VERSION

--- a/src/targets/builtins.rs
+++ b/src/targets/builtins.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 
-pub(crate) const RUSTC_VERSION: &str = "1.71.0";
+pub(crate) const RUSTC_VERSION: &str = "1.72.0";
 
 pub const ALL_BUILTINS: &[TargetInfo] = &[
     TargetInfo {
@@ -404,6 +404,19 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         panic: Panic::unwind,
     },
     TargetInfo {
+        triple: Triple::new_const("aarch64_be-unknown-netbsd"),
+        os: Some(Os::netbsd),
+        abi: None,
+        arch: Arch::aarch64,
+        env: None,
+        vendor: Some(Vendor::unknown),
+        families: Families::unix,
+        pointer_width: 64,
+        endian: Endian::big,
+        has_atomics: HasAtomics::atomic_8_16_32_64_128_ptr,
+        panic: Panic::unwind,
+    },
+    TargetInfo {
         triple: Triple::new_const("arm-linux-androideabi"),
         os: Some(Os::android),
         abi: None,
@@ -674,7 +687,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         pointer_width: 32,
         endian: Endian::little,
         has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
-        panic: Panic::abort,
+        panic: Panic::unwind,
     },
     TargetInfo {
         triple: Triple::new_const("armv7-unknown-freebsd"),
@@ -1236,6 +1249,32 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         panic: Panic::unwind,
     },
     TargetInfo {
+        triple: Triple::new_const("loongarch64-unknown-none"),
+        os: None,
+        abi: None,
+        arch: Arch::loongarch64,
+        env: None,
+        vendor: Some(Vendor::unknown),
+        families: Families::new_const(&[]),
+        pointer_width: 64,
+        endian: Endian::little,
+        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        panic: Panic::abort,
+    },
+    TargetInfo {
+        triple: Triple::new_const("loongarch64-unknown-none-softfloat"),
+        os: None,
+        abi: None,
+        arch: Arch::loongarch64,
+        env: None,
+        vendor: Some(Vendor::unknown),
+        families: Families::new_const(&[]),
+        pointer_width: 64,
+        endian: Endian::little,
+        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        panic: Panic::abort,
+    },
+    TargetInfo {
         triple: Triple::new_const("m68k-unknown-linux-gnu"),
         os: Some(Os::linux),
         abi: None,
@@ -1782,6 +1821,19 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         panic: Panic::abort,
     },
     TargetInfo {
+        triple: Triple::new_const("riscv32imac-esp-espidf"),
+        os: Some(Os::espidf),
+        abi: None,
+        arch: Arch::riscv32,
+        env: Some(Env::newlib),
+        vendor: Some(Vendor::espressif),
+        families: Families::unix,
+        pointer_width: 32,
+        endian: Endian::little,
+        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        panic: Panic::abort,
+    },
+    TargetInfo {
         triple: Triple::new_const("riscv32imac-unknown-none-elf"),
         os: None,
         abi: None,
@@ -1878,6 +1930,19 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         abi: None,
         arch: Arch::riscv64,
         env: Some(Env::musl),
+        vendor: Some(Vendor::unknown),
+        families: Families::unix,
+        pointer_width: 64,
+        endian: Endian::little,
+        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        panic: Panic::unwind,
+    },
+    TargetInfo {
+        triple: Triple::new_const("riscv64gc-unknown-netbsd"),
+        os: Some(Os::netbsd),
+        abi: None,
+        arch: Arch::riscv64,
+        env: None,
         vendor: Some(Vendor::unknown),
         families: Families::unix,
         pointer_width: 64,
@@ -2272,7 +2337,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         families: Families::unix,
         pointer_width: 64,
         endian: Endian::little,
-        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        has_atomics: HasAtomics::atomic_8_16_32_64_128_ptr,
         panic: Panic::unwind,
     },
     TargetInfo {
@@ -2285,7 +2350,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         families: Families::unix,
         pointer_width: 64,
         endian: Endian::little,
-        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        has_atomics: HasAtomics::atomic_8_16_32_64_128_ptr,
         panic: Panic::unwind,
     },
     TargetInfo {
@@ -2298,7 +2363,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         families: Families::unix,
         pointer_width: 64,
         endian: Endian::little,
-        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        has_atomics: HasAtomics::atomic_8_16_32_64_128_ptr,
         panic: Panic::unwind,
     },
     TargetInfo {
@@ -2311,7 +2376,7 @@ pub const ALL_BUILTINS: &[TargetInfo] = &[
         families: Families::unix,
         pointer_width: 64,
         endian: Endian::little,
-        has_atomics: HasAtomics::atomic_8_16_32_64_ptr,
+        has_atomics: HasAtomics::atomic_8_16_32_64_128_ptr,
         panic: Panic::unwind,
     },
     TargetInfo {


### PR DESCRIPTION
Also changes target-lexicon semver to the current latest for those using unstable cargo flags https://github.com/EmbarkStudios/cfg-expr/pull/63#issuecomment-1711426117