### PR TITLE
build(deps): Update `target-lexicon` to 0.12.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ targets = ["target-lexicon"]
 
 [dependencies]
 smallvec = "1.8"
-target-lexicon = { version = "0.12.11", optional = true }
+target-lexicon = { version = "0.12.15", optional = true }
 
 [dev-dependencies]
 similar-asserts = "1.1"


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This crate fails to build with version 0.12.11. So the minimal version should be 0.12.15.

### Related Issues

https://github.com/EmbarkStudios/cfg-expr/pull/71 will check the minimal versions in CI to prevent this from happening again.
